### PR TITLE
Detect `pdb.set_trace`, add test for `set_trace` calls

### DIFF
--- a/flake8_debug/plugin.py
+++ b/flake8_debug/plugin.py
@@ -17,6 +17,9 @@ class DebugVisitor(ast.NodeVisitor):
             if (
                 isinstance(node.func, ast.Name)
                 and node.func.id == error.func_name
+            ) or (
+                isinstance(node.func, ast.Attribute)
+                and node.func.attr == error.func_name
             ):
                 self.issues.append((node.lineno, node.col_offset, error().msg))
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 black==22.1.0
-flake8==4.0.1
+flake8>=4.0.1
 pytest==7.0.1
 pytest-cov==3.0.0
 coverage==5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-flake8==4.0.1
+flake8>=4.0.1
 astpretty==2.1.0

--- a/tests/flake8_debug_test.py
+++ b/tests/flake8_debug_test.py
@@ -8,6 +8,7 @@ from flake8_debug.errors import (
     PrintError,
     BreakpointError,
     BreakpointHookError,
+    PdbError,
 )
 from flake8_debug.plugin import NoDebug
 
@@ -76,4 +77,20 @@ def test_present_multiple_breakpointhooks():
         'breakpointhook(0)\n    breakpointhook(0)'
     ) == tuple(
         _out(line, column=5, err=BreakpointHookError()) for line in (3, 4)
+    )
+
+
+def test_present_set_trace():
+    assert _plugin_results(
+        'def f():\n    import pdb\n    pdb.set_trace()'
+    ) == (
+        _out(line=3, column=5, err=PdbError()),
+    )
+
+
+def test_present_bare_set_trace():
+    assert _plugin_results(
+        'def f():\n    from pdb import set_trace\n    set_trace()'
+    ) == (
+        _out(line=3, column=5, err=PdbError()),
     )


### PR DESCRIPTION
Hi there!

This is my attempt to fix https://github.com/vyahello/flake8-debug/issues/6 — let me know if that looks OK @vyahello.

As part of this, I also bumped the flake8 version so it will allow for newer flake8 versions — this was necessary to get flake8-debug to work with the newer flake8 version that we are using in our project. But if that change is not desirable at this time, I can remove it from this PR.